### PR TITLE
Fix code block parsing and preserve icon/description in custom templates

### DIFF
--- a/app/api/custom-templates/route.ts
+++ b/app/api/custom-templates/route.ts
@@ -53,11 +53,11 @@ export async function GET() {
         codeLines = []
       }
       // Icon field
-      else if (trimmed.startsWith('icon:') && currentTemplate) {
+      else if (!inCodeBlock && trimmed.startsWith('icon:') && currentTemplate) {
         currentTemplate.icon = trimmed.replace('icon:', '').replace(/['"]/g, '').trim()
       }
       // Description field
-      else if (trimmed.startsWith('description:') && currentTemplate) {
+      else if (!inCodeBlock && trimmed.startsWith('description:') && currentTemplate) {
         currentTemplate.description = trimmed.replace('description:', '').replace(/['"]/g, '').trim()
       }
       // Code field


### PR DESCRIPTION
This PR updates the custom template parser to:

- Fix YAML code parser to correctly strip the first 6 spaces from code blocks while preserving the remaining indentation. (Related to #12)

- Add `!inCodeBlock` checks for `icon` and `description` fields to prevent lines inside code blocks from being misinterpreted. (Related to #11 )

