### PR TITLE
fix(ci): google font importing causing image building to fail

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ['latin'], display: 'swap', adjustFontFallback: false})
 
 export const metadata: Metadata = {
   title: "Compose Toolbox",


### PR DESCRIPTION
tho i'm not a frontend dev, i did some research and found adding some settings to the font fixed the image building issue.
but i have absolutely no idea what's the result of this modification. plz make sure it works as expected.

ref: https://stackoverflow.com/questions/76478043/next-js-always-fail-at-downloading-fonts-from-google-fonts